### PR TITLE
Support Readest config schema v2 and v3

### DIFF
--- a/src/readest.ts
+++ b/src/readest.ts
@@ -7,7 +7,13 @@ import type {
   ReadestLibraryBook,
 } from "./types";
 
-export const SUPPORTED_SCHEMA_VERSION = 1;
+// Readest's current BOOK_CONFIG_SCHEMA_VERSION is 3. The booknote record shape
+// this plugin reads is stable across v1-v3: the v1->v2 migration only unifies a
+// split highlight+note pair into a single record (Readest's
+// utils/booknoteMigration.ts), and v2->v3 only changes searchConfig (a new search
+// `mode` enum). Neither touches the booknote fields consumed here, so configs up
+// to v3 are safe to read directly.
+export const SUPPORTED_SCHEMA_VERSION = 3;
 
 function isEnoent(e: unknown): boolean {
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface ReadestAnnotation {
   cfi?: string;
   page?: number;
   text: string;
-  style: "highlight" | "underline" | null;
+  style: "highlight" | "underline" | "squiggly" | null;
   color: string | null;
   note: string;
   createdAt: number;

--- a/tests/readest.test.ts
+++ b/tests/readest.test.ts
@@ -134,6 +134,33 @@ void test("highest unsupported version is reported when multiple books exceed", 
   assert.deepEqual(seen, [SUPPORTED_SCHEMA_VERSION + 3]);
 });
 
+void test("supported schema versions (v2, v3) parse without warning", async (t) => {
+  const dir = await makeBooksDir(
+    t,
+    {
+      h2: {
+        bookHash: "h2",
+        schemaVersion: 2,
+        booknotes: [{ ...baseAnnotation, bookHash: "h2", id: "a2" }],
+      },
+      h3: {
+        bookHash: "h3",
+        schemaVersion: 3,
+        booknotes: [{ ...baseAnnotation, bookHash: "h3", id: "a3" }],
+      },
+    },
+    [libraryEntry("h2"), libraryEntry("h3")],
+  );
+  let called = false;
+  const books = await loadBooksWithAnnotations(dir, {
+    onUnsupportedSchema: () => {
+      called = true;
+    },
+  });
+  assert.equal(called, false);
+  assert.equal(books.length, 2);
+});
+
 // --- parse error reporting ---
 
 void test("malformed library.json throws error mentioning the path", async (t) => {


### PR DESCRIPTION
## Problem

On current Readest, every sync shows **"config schema v2 is newer than supported (v1). Update the Readest Highlights plugin."** and `Sync all books` reports `0 created, 0 updated`, so users assume the integration is broken.

## Root cause

`SUPPORTED_SCHEMA_VERSION` is pinned at `1`, but Readest's `BOOK_CONFIG_SCHEMA_VERSION` is now `3` (`apps/readest-app/src/types/book.ts`). Neither bump changes the `booknotes` shape this plugin reads:

- **v1 → v2** (`utils/booknoteMigration.ts`): unifies a split highlight+note pair at the same CFI into a single record. The `BookNote` fields are unchanged (and the unified record is actually easier to render).
- **v2 → v3** (`utils/serializer.ts`): only adds a `mode` enum to `searchConfig`. Nothing to do with booknotes.

`loadBooksWithAnnotations` already parses booknotes regardless of version — the version check only fires the `onUnsupportedSchema` notice — so the stale constant's only user-visible effect is the false "update the plugin" warning.

## Change

- Raise `SUPPORTED_SCHEMA_VERSION` `1 → 3`, with a comment recording why v2/v3 are read-safe.
- Add `"squiggly"` to the annotation `style` union (Readest emits it as a third highlight style).
- Add a regression test: v2 and v3 configs with booknotes parse **without** triggering `onUnsupportedSchema` and return their annotations.

## Testing

- `npm test` — 36/36 pass (including the new case).
- `npm run build` — clean `tsc` typecheck + esbuild production build.
