### PR TITLE
feat: add option to collapse line breaks within a highlight

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -161,7 +161,8 @@ How each highlight is rendered in markdown:
 
 How line breaks within highlights are handled:
 
-- Toggle off to preserve line breaks within highlights that span multiple paragraphs or toggle on to replace line breaks with a space. 
+- **Off** (default): preserve line breaks in highlights that span multiple paragraphs
+- **On**: replace line breaks with a space
 
 #### Separator
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -157,6 +157,12 @@ How each highlight is rendered in markdown:
 - **Callout** (`> [!quote]` block)
 - **Bullet** (`- text`)
 
+#### Collapse line breaks
+
+How line breaks within highlights are handled:
+
+- Toggle off to preserve line breaks within highlights that span multiple paragraphs or toggle on to replace line breaks with a space. 
+
 #### Separator
 
 How highlights are separated within a book note:

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -31,6 +31,7 @@ export interface RenderOptions {
   showPage: boolean;
   showColor: boolean;
   showHighlightCount: boolean;
+  collapseHighlightLineBreaks: boolean;
   renderUnderlines: boolean;
   metadataPlacement: MetadataPlacement;
   showNotes: boolean;
@@ -55,6 +56,7 @@ export function optionsFromSettings(s: ReadestSettings): RenderOptions {
     showPage: s.showPage,
     showColor: s.showColor,
     showHighlightCount: s.showHighlightCount,
+    collapseHighlightLineBreaks: s.collapseHighlightLineBreaks,
     renderUnderlines: s.renderUnderlines,
     metadataPlacement: s.metadataPlacement,
     showNotes: s.showNotes,
@@ -225,12 +227,12 @@ export function bookFilename(
   return `${capped}.md`;
 }
 
-function cleanText(text: string): string {
+function cleanText(text: string, collapseLineBreaks: boolean): string {
   return text
     .split(/\n+/)
     .map((line) => line.replace(/[\t ]+/g, " ").trim())
     .filter((line) => line.length > 0)
-    .join("\n");
+    .join(collapseLineBreaks ? " " : "\n");
 }
 
 interface GroupedAnnotation {
@@ -245,6 +247,7 @@ interface GroupedAnnotation {
 
 function groupAnnotations(
   annotations: ReadestAnnotation[],
+  opts: Pick<RenderOptions, "collapseHighlightLineBreaks">,
 ): GroupedAnnotation[] {
   // Records are grouped by location (cfi, falling back to page) so a highlight
   // and a separate note/color/style record at the same spot render as one
@@ -257,7 +260,7 @@ function groupAnnotations(
   const order: GroupedAnnotation[] = [];
 
   for (const a of annotations) {
-    const cleaned = cleanText(a.text ?? "");
+    const cleaned = cleanText(a.text ?? "", opts.collapseHighlightLineBreaks);
     const location = a.cfi ?? `p${a.page ?? 0}`;
     const groups = byLocation.get(location) ?? [];
     const target = groups.find(
@@ -409,7 +412,7 @@ export function renderHighlightsBody(
   annotations: ReadestAnnotation[],
   opts: RenderOptions,
 ): string {
-  const groups = groupAnnotations(annotations);
+  const groups = groupAnnotations(annotations, opts);
   if (groups.length === 0) return "";
 
   if (opts.separator === "pageHeading") {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,6 +27,7 @@ export interface ReadestSettings {
   showPage: boolean;
   showColor: boolean;
   showHighlightCount: boolean;
+  collapseHighlightLineBreaks: boolean;
   renderUnderlines: boolean;
   metadataPlacement: MetadataPlacement;
   showNotes: boolean;
@@ -123,6 +124,7 @@ export const DEFAULT_SETTINGS: ReadestSettings = {
   showPage: true,
   showColor: false,
   showHighlightCount: false,
+  collapseHighlightLineBreaks: false,
   renderUnderlines: true,
   metadataPlacement: "below",
   showNotes: true,
@@ -676,6 +678,18 @@ export class ReadestSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.highlightStyle)
           .onChange(async (value) => {
             this.plugin.settings.highlightStyle = value as HighlightStyle;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(hl)
+      .setName("Collapse line breaks")
+      .setDesc("Replace line breaks inside highlight text with spaces.")
+      .addToggle((t) =>
+        t
+          .setValue(this.plugin.settings.collapseHighlightLineBreaks)
+          .onChange(async (value) => {
+            this.plugin.settings.collapseHighlightLineBreaks = value;
             await this.plugin.saveSettings();
           }),
       );

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -32,6 +32,7 @@ const opts: RenderOptions = {
   showPage: true,
   showColor: false,
   showHighlightCount: false,
+  collapseHighlightLineBreaks: false,
   renderUnderlines: true,
   metadataPlacement: "below",
   showNotes: true,


### PR DESCRIPTION
## Summary

Adds a rendering setting that collapses line breaks inside highlights before they are written to Markdown. 

I have a handful of highlights in my Readest library that span paragraphs. In those cases, I found the text exported by the plugin a  bit hard to read because of line breaks that were inserted in the Markdown at paragraph boundaries.

The existing behavior stays the default, and the cleanup only runs if the new setting is toggled on.

## Changes

- Adds a “Collapse line breaks” toggle under Rendering > Highlights
- Wires the setting through the renderer
- Keeps the current line-break behavior as the default
- Updates renderer tests for the new option
- Updates settings documentation for the new option

## Screenshots

<img width="756" height="480" alt="Screenshot 2026-07-07 233437" src="https://github.com/user-attachments/assets/9d4fdcfe-cbee-43c2-afd0-d7e451fb5bf8" />
</br></br>

<img width="1139" height="640" alt="Obsidian - 2026-07-08 at 12-10-11-509 AM" src="https://github.com/user-attachments/assets/b0d779df-5e56-4ad3-8269-ad8fc1fadd55" />
Collapse line breaks toggled off.
</br></br>

<img width="1127" height="645" alt="Obsidian - 2026-07-08 at 12-10-33-404 AM" src="https://github.com/user-attachments/assets/8d1d62ec-08bb-415d-93c0-2e3e63a559fe" />
Collapse line breaks toggled on.
</br></br>


## Test Plan

- Ran `npm test`
- Ran `npm run build`
- Used the plugin in a local Obsidian vault connected to Readest
- Verified that a highlight spanning multiple paragraph keeps its existing line breaks when the setting is off
- Verified that line breaks inside a highlight that spans multiple paragraphs are converted to spaces when the setting is on
